### PR TITLE
Feat: Handle client_type during user registration for smart mobile app redirects

### DIFF
--- a/website/user_profile/api/serializers.py
+++ b/website/user_profile/api/serializers.py
@@ -40,6 +40,7 @@ from user_profile.utils import LowerEmailField
 class RegistrationSerializer(serializers.ModelSerializer):
     password2 = serializers.CharField(write_only=True)
     dept = serializers.CharField(max_length=70, required=False, allow_blank=True)
+    client_type = serializers.CharField(max_length=20, required=False, default='web', write_only=True)
 
     email = LowerEmailField(
         required=True,
@@ -50,7 +51,7 @@ class RegistrationSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = User
-        fields = ['username', 'email', 'password', 'password2', 'dept']
+        fields = ['username', 'email', 'password', 'password2', 'dept', 'client_type']
         extra_kwargs = {
             'password': {'write_only': True}
         }
@@ -65,6 +66,7 @@ class RegistrationSerializer(serializers.ModelSerializer):
     def create(self, validated_data):
         validated_data.pop('password2')
         dept = validated_data.pop('dept', None)
+        client_type = validated_data.pop('client_type', 'web')
 
         user = User.objects.create_user(
             username=validated_data['username'],
@@ -73,8 +75,9 @@ class RegistrationSerializer(serializers.ModelSerializer):
             is_active=False
         )
         
-        if dept:
+        if dept or client_type:
             user.profile.dept = dept
+            user.profile.client_type = client_type
             user.profile.save()
 
         return user

--- a/website/user_profile/models.py
+++ b/website/user_profile/models.py
@@ -44,6 +44,16 @@ class Profile(ExportModelOperationsMixin('profile'), models.Model):
     image_url = models.URLField(blank=True, null=True)
     image = models.ImageField(blank=True, null=True, upload_to=content_file_name)
     email_confirmed = models.BooleanField(default=False)
+    client_type = models.CharField(
+        max_length=20,
+        choices=[
+            ('web', 'Web'),
+            ('flutter', 'Flutter App'),
+            ('ios', 'iOS App'),
+            ('android', 'Android App'),
+        ],
+        default='web'
+    )
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
 

--- a/website/user_profile/views.py
+++ b/website/user_profile/views.py
@@ -177,9 +177,20 @@ def activate(request, uidb64, token, backend='django.contrib.auth.backends.Model
             profile.image.name = rel_media  # set path relative to MEDIA_ROOT
             profile.save()
 
-        if profile.user == request.user:
+        # Redirect based on client type
+        client_type = profile.client_type
+
+        if client_type == 'flutter' or client_type == 'android':
+            # For Flutter/Android app - use deep link with app package name
+            deep_link = f"com.recursionnitd.app://verify?email={user.email}&status=success"
+            return redirect(deep_link)
+        elif client_type == 'ios':
+            # For iOS app - use app scheme
+            deep_link = f"com.recursionnitd.app://verify?email={user.email}&status=success"
+            return redirect(deep_link)
+        else:
+            # For web - use website URL
             return redirect(settings.FRONTEND_BASE_URL + '/profile/edit?activated=true')
-        return redirect(settings.FRONTEND_BASE_URL + '/profile/edit?activated=true')
     else:
         return render(request, 'account_activation_invalid.html')
 


### PR DESCRIPTION
## Overview
This PR improves the backend authentication & registration flows to dynamically detect where a user is registering from (Web vs Mobile App) and safely route them back to their natively originating platform once their email is successfully verified.

Previously, users creating accounts using the mobile application were always stranded inside their mobile browser after clicking the verification link sent to their email. 

### Key Changes
1. **Model Expansion (`user_profile/models.py`)** 
   - Introduced a `client_type` column (choices: `web`, `flutter`, `android`, `ios`) securely into the `Profile` database schema.

2. **API Registration Updates (`user_profile/api/serializers.py`)**
   - Expanded the `RegistrationSerializer` to automatically parse `client_type` from incoming POST payloads.
   - Refactored the `create()` method so `client_type` and existing attributes like `dept` safely hydrate into the user's Profile record on successful creation.

3. **Smart Conditional Deep-Linking (`user_profile/views.py`)** 
   - Rewrote the `activate` routing mechanism logic. 
   - When a user verifies their email via their browser, Django intercepts the request. If their profile indicates they registered from a mobile app (`flutter`, `android`, or `ios`), it triggers a deep-link redirect straight back into the application (`com.recursionnitd.app://verify?email=[email]&status=success`).
   - Web users are safely defaulted to standard Website frontend redirects as normal.
