### PR TITLE
chore: add docker configuration for local development

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.git
+.gitignore
+.venv39
+venv
+__pycache__
+*.pyc
+*.pyo
+*.pyd
+db.sqlite3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+# Use official lightweight Python 3.11 image
+FROM python:3.11-slim
+
+# Prevent Python from writing .pyc files and enable unbuffered logging
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+# Install system dependencies required for building wheels (mysqlclient, Pillow)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    default-libmysqlclient-dev \
+    pkg-config \
+    libjpeg-dev \
+    zlib1g-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy requirements and install
+COPY requirements.txt /app/
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy the rest of the backend code
+COPY . /app/
+
+EXPOSE 8000
+
+# Run the development server
+CMD ["python", "website/manage.py", "runserver", "0.0.0.0:8000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,41 @@
+version: '3.8'
+
+services:
+  backend:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: recursion-backend
+    ports:
+      - "8000:8000"
+    volumes:
+      # Mount the website folder to preserve the db.sqlite3 and allow hot-reloading
+      - ./website:/app/website
+    env_file:
+      - ./website/.env
+    environment:
+      # Override the host-specific database path to the container path
+      - DATABASE_URL=sqlite:////app/website/db.sqlite3
+      - FRONTEND_BASE_URL=http://localhost:3000
+    restart: always
+
+  frontend:
+    build:
+      context: ../RECursionNITD-Frontend
+      dockerfile: Dockerfile
+    container_name: recursion-frontend
+    ports:
+      - "3000:3000"
+    volumes:
+      - ../RECursionNITD-Frontend/src:/app/src
+      - ../RECursionNITD-Frontend/public:/app/public
+    env_file:
+      - ../RECursionNITD-Frontend/.env
+    environment:
+      - REACT_APP_BACKEND_URL=http://localhost:8000
+    # Required for Create React App to stay alive in Docker
+    stdin_open: true
+    tty: true
+    restart: always
+    depends_on:
+      - backend


### PR DESCRIPTION
## Description
This PR introduces a robust Docker configuration to containerise the local development environment. It aims to solve local environment friction (specifically macOS `mysqlclient` C-library installation issues) and simplifies the setup process for new contributors. 

This PR acts as the central orchestrator for the entire stack, spinning up both the backend and frontend simultaneously via `docker-compose.yml`.

## Changes Made
* **`Dockerfile`**: Added a Python 3.11-slim container that natively installs the required system dependencies (`libmysqlclient-dev`, `libjpeg-dev`) to successfully compile `mysqlclient` and `Pillow`.
* **`docker-compose.yml`**: Added a central compose file that builds and networks both the backend and the adjacent `RECursionNITD-Frontend` repository.
* **Volume Mounts**: Configured volume mounts for the `website/` directory to ensure hot-reloading works out of the box and the massive 133MB `db.sqlite3` database safely persists on the host machine.
* **`.dockerignore`**: Added to ignore virtual environments and cache files.

## How to Test
1. Ensure both the backend and frontend repositories are cloned into the same parent folder.
2. Ensure Docker Desktop is running.
3. Run `docker compose up -d --build` inside this repository.
4. Visit `http://localhost:3000` to interact with the full containerised stack.

> **Note:** This PR must be merged at the exact same time as the corresponding [Frontend Docker PR #79](https://github.com/RECursion-NITD/RECursionNITD-Frontend/pull/79). The `docker-compose.yml` file in this PR relies on the `Dockerfile` being present in the frontend repository to successfully build the local environment.